### PR TITLE
allow newer versions of yum-epel cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -46,7 +46,7 @@ supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
 
-depends 'yum-epel', '~> 0.5'
+depends 'yum-epel', '>= 0.5', '<= 4.0'
 
 recipe 'opendkim::default', 'Installs and configures OpenDKIM.'
 


### PR DESCRIPTION
### Description

Allow newer versions (`0.5.x - 3.x.y`, inclusive) of the `yum-epel` cookbook, to support nodes using newer versions of Chef that don't support the [most recent version supported by the cookbook](https://github.com/chef-cookbooks/yum-epel/releases/tag/v0.7.1).

[yum-epel](https://github.com/chef-cookbooks/yum-epel) is on `v3.1.0` and this cookbook shouldn't have any breaking changes by allowing newer versions as dependencies, given our simple use case.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/opendkim-cookbook/blob/master/CONTRIBUTING.md).
