### PR TITLE
Works with yum-epel v3.3.0 in my environment

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -25,7 +25,7 @@ description <<-EOH
   (Domain Keys Identified Mail) sender authentication system.
 EOH
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.0' # WiP
+version '2.1.1' # WiP
 
 if respond_to?(:source_url)
   source_url "https://github.com/zuazo/#{name}-cookbook"
@@ -46,7 +46,7 @@ supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
 
-depends 'yum-epel', '~> 0.5'
+depends 'yum-epel', '>= 0.0.0'
 
 recipe 'opendkim::default', 'Installs and configures OpenDKIM.'
 


### PR DESCRIPTION
### Description

Changes yum-epel dependancy from ~> 0.5 to any version

### Issues Resolved

Did not work in my env because my yum-epel version was too high

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/opendkim-cookbook/blob/master/CONTRIBUTING.md).
